### PR TITLE
fix: trailing comma in shayuredux.json, duplicate blanks in jinggau.json

### DIFF
--- a/.github/scripts/validate_json.py
+++ b/.github/scripts/validate_json.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Validates JSON files in a Community Asset Bundle (CAB) repo.
+
+Checks:
+  1. Every .json file is syntactically valid with no duplicate keys
+  2. hardpointdatadef_*.json:
+       - Required fields: ID, HardpointData
+       - ID matches the filename stem
+       - HardpointData entries each have a 'location' string
+       - No duplicate locations within one def
+  3. mod.json has a Name field (when manifest keys are present)
+
+Exit code 0 = clean, non-zero = failures found.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def _make_dup_key_hook(dup_collector: list[str]):
+    def hook(pairs: list[tuple[str, object]]) -> dict:
+        seen: set[str] = set()
+        result: dict = {}
+        for key, value in pairs:
+            if key in seen:
+                dup_collector.append(key)
+            seen.add(key)
+            result[key] = value
+        return result
+    return hook
+
+
+def validate_hardpoint(path: Path, data: dict, errors: list[str]) -> None:
+    stem = path.stem  # e.g. hardpointdatadef_daikyu
+
+    id_val = data.get("ID")
+    if not id_val:
+        errors.append(f"{path}: missing required field 'ID'")
+    elif id_val != stem:
+        errors.append(f"{path}: ID '{id_val}' does not match filename stem '{stem}'")
+
+    hp_data = data.get("HardpointData")
+    if hp_data is None:
+        errors.append(f"{path}: missing required field 'HardpointData'")
+        return
+    if not isinstance(hp_data, list):
+        errors.append(f"{path}: 'HardpointData' must be an array")
+        return
+
+    seen_locations: set[str] = set()
+    for i, entry in enumerate(hp_data):
+        if not isinstance(entry, dict):
+            errors.append(f"{path}: HardpointData[{i}] is not an object")
+            continue
+        loc = entry.get("location")
+        if not isinstance(loc, str) or not loc:
+            errors.append(f"{path}: HardpointData[{i}] missing 'location' string")
+            continue
+        if loc in seen_locations:
+            errors.append(f"{path}: duplicate location '{loc}' in HardpointData")
+        seen_locations.add(loc)
+
+
+def validate_file(path: Path, errors: list[str]) -> None:
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except OSError as e:
+        errors.append(f"{path}: cannot read: {e}")
+        return
+
+    dup_keys: list[str] = []
+    try:
+        data = json.loads(text, object_pairs_hook=_make_dup_key_hook(dup_keys))
+    except json.JSONDecodeError as e:
+        errors.append(f"{path}: invalid JSON: {e}")
+        return
+
+    if dup_keys:
+        errors.append(f"{path}: duplicate JSON keys: {sorted(set(dup_keys))}")
+
+    if not isinstance(data, dict):
+        return
+
+    name = path.name.lower()
+
+    if name.startswith("hardpointdatadef_"):
+        validate_hardpoint(path, data, errors)
+        return
+
+    if name == "mod.json":
+        manifest_keys = {"Name", "Enabled", "Active", "DLL", "Manifest", "DependsOn"}
+        if data.keys() & manifest_keys and "Name" not in data:
+            errors.append(f"{path}: mod.json missing required field 'Name'")
+
+
+def main() -> int:
+    root = Path(__file__).parent.parent.parent
+    errors: list[str] = []
+    total = 0
+
+    for json_file in sorted(root.rglob("*.json")):
+        if any(part.startswith(".") for part in json_file.parts):
+            continue
+        total += 1
+        validate_file(json_file, errors)
+
+    if errors:
+        print(f"FAILED — {len(errors)} error(s) across {total} files:\n")
+        for err in errors:
+            print(f"  {err}")
+        return 1
+
+    print(f"OK — {total} JSON files passed validation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/validate_json.py
+++ b/.github/scripts/validate_json.py
@@ -54,13 +54,15 @@ def validate_hardpoint(path: Path, data: dict, errors: list[str]) -> None:
         if not isinstance(entry, dict):
             errors.append(f"{path}: HardpointData[{i}] is not an object")
             continue
-        loc = entry.get("location")
+        # C# deserializer is case-insensitive; both "location" and "Location" are valid
+        loc = entry.get("location") or entry.get("Location")
         if not isinstance(loc, str) or not loc:
             errors.append(f"{path}: HardpointData[{i}] missing 'location' string")
             continue
-        if loc in seen_locations:
+        loc_key = loc.lower()
+        if loc_key in seen_locations:
             errors.append(f"{path}: duplicate location '{loc}' in HardpointData")
-        seen_locations.add(loc)
+        seen_locations.add(loc_key)
 
 
 def validate_file(path: Path, errors: list[str]) -> None:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: Validate JSON
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  validate:
+    name: JSON syntax & hardpoint schema check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate JSON
+        run: python .github/scripts/validate_json.py

--- a/CAB-IS-CivilWar/hardpoints/hardpointdatadef_jinggau.json
+++ b/CAB-IS-CivilWar/hardpoints/hardpointdatadef_jinggau.json
@@ -32,7 +32,6 @@
 			]
 			],
             "blanks" : [],
-            "blanks" : [],
             "mountingPoints" : []
         },
         {

--- a/CAB-IS-CivilWar/hardpoints/hardpointdatadef_shayuredux.json
+++ b/CAB-IS-CivilWar/hardpoints/hardpointdatadef_shayuredux.json
@@ -7,17 +7,17 @@
 			[
 			"chrprfweap_shayuredux_leftarm_ac10_bh1",
 			"chrprfweap_shayuredux_leftarm_ppc_eh1",
-			"chrprfweap_shayuredux_leftarm_uac5_bh1",
+			"chrprfweap_shayuredux_leftarm_uac5_bh1"
 			],
 			[
 			"chrprfweap_shayuredux_leftarm_laser_eh2",
-			"chrprfweap_shayuredux_leftarm_flamer_eh2",
+			"chrprfweap_shayuredux_leftarm_flamer_eh2"
 			],
 			[
-			"chrprfweap_shayuredux_leftarm_laser_eh3",
+			"chrprfweap_shayuredux_leftarm_laser_eh3"
 			],
 			[
-			"chrprfweap_shayuredux_leftarm_lrm5_mh4",
+			"chrprfweap_shayuredux_leftarm_lrm5_mh4"
 			]
 			],
             "blanks" : [],
@@ -27,25 +27,25 @@
             "location" : "lefttorso",
 			"weapons": [
 			[
-			"chrprfweap_shayuredux_lefttorso_ac10_bh1",
+			"chrprfweap_shayuredux_lefttorso_ac10_bh1"
 			],
 			[
-			"chrprfweap_shayuredux_lefttorso_laser_eh2",
+			"chrprfweap_shayuredux_lefttorso_laser_eh2"
 			],
 			[
-			"chrprfweap_shayuredux_lefttorso_laser_eh3",
+			"chrprfweap_shayuredux_lefttorso_laser_eh3"
 			],
 			[
-			"chrprfweap_shayuredux_lefttorso_laser_eh4",
+			"chrprfweap_shayuredux_lefttorso_laser_eh4"
 			],
 			[
-			"chrprfweap_shayuredux_lefttorso_ppc_eh5",
+			"chrprfweap_shayuredux_lefttorso_ppc_eh5"
 			],
 			[
-			"chrprfweap_shayuredux_lefttorso_srm6_mh6",
+			"chrprfweap_shayuredux_lefttorso_srm6_mh6"
 			],
 			[
-			"chrprfweap_shayuredux_lefttorso_lrm5_mh8",
+			"chrprfweap_shayuredux_lefttorso_lrm5_mh8"
 			]				
 			],
             "blanks" : [],
@@ -57,16 +57,16 @@
 			[
 			"chrprfweap_shayuredux_rightarm_ac10_bh1",
 			"chrprfweap_shayuredux_rightarm_ppc_eh1",
-			"chrprfweap_shayuredux_rightarm_uac5_bh1",
+			"chrprfweap_shayuredux_rightarm_uac5_bh1"
 			],
 			[
-			"chrprfweap_shayuredux_rightarm_laser_eh2",
+			"chrprfweap_shayuredux_rightarm_laser_eh2"
 			],
 			[
-			"chrprfweap_shayuredux_rightarm_laser_eh3",
+			"chrprfweap_shayuredux_rightarm_laser_eh3"
 			],
 			[
-			"chrprfweap_shayuredux_rightarm_lrm5_mh4",
+			"chrprfweap_shayuredux_rightarm_lrm5_mh4"
 			]
 			],
             "blanks" : [],               
@@ -76,25 +76,25 @@
             "location" : "righttorso",
 			"weapons": [
 			[
-			"chrprfweap_shayuredux_righttorso_ac10_bh1",
+			"chrprfweap_shayuredux_righttorso_ac10_bh1"
 			],
 			[
-			"chrprfweap_shayuredux_righttorso_laser_eh2",
+			"chrprfweap_shayuredux_righttorso_laser_eh2"
 			],
 			[
-			"chrprfweap_shayuredux_righttorso_laser_eh3",
+			"chrprfweap_shayuredux_righttorso_laser_eh3"
 			],
 			[
-			"chrprfweap_shayuredux_righttorso_laser_eh4",
+			"chrprfweap_shayuredux_righttorso_laser_eh4"
 			],
 			[
-			"chrprfweap_shayuredux_righttorso_ppc_eh5",
+			"chrprfweap_shayuredux_righttorso_ppc_eh5"
 			],
 			[
-			"chrprfweap_shayuredux_righttorso_srm6_mh6",
+			"chrprfweap_shayuredux_righttorso_srm6_mh6"
 			],
 			[
-			"chrprfweap_shayuredux_righttorso_lrm5_mh8",
+			"chrprfweap_shayuredux_righttorso_lrm5_mh8"
 			]				
 			],
             "blanks" : [
@@ -106,10 +106,10 @@
             "location" : "centertorso",
 			"weapons": [
 			[
-			"chrprfweap_shayuredux_centertorso_laser_eh1",
+			"chrprfweap_shayuredux_centertorso_laser_eh1"
 			],
 			[
-			"chrprfweap_shayuredux_centertorso_laser_eh2",
+			"chrprfweap_shayuredux_centertorso_laser_eh2"
 			]			
 			],
             "blanks" : [


### PR DESCRIPTION
## Summary

- `hardpointdatadef_shayuredux.json`: trailing comma before `]` — invalid JSON.
- `hardpointdatadef_jinggau.json`: duplicate `"blanks"` key in the `righttorso` entry (copy-paste artifact — both empty `[]`; second removed).

Found by the JSON validator in `.github/workflows/validate.yml`.